### PR TITLE
Improve formality of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Poketask
-> A simple command to start any project. Create a README.md, LICENSE, .gitignore, .gitattributes and .editorconfig with one command line.
+> A simple command to start any project. Run the command to create a README.md, LICENSE, .gitignore, .gitattributes, and .editorconfig with a one-line command.
 
-Now it's compatible with older Node versions
+Currently, it is compatible with older Node versions.
 
 ## Installation
 ```bash
@@ -9,7 +9,7 @@ npm install -g poketask
 ```
 
 ## Usage
-In your project's root folder. Recommended after doing npm init. It will create a README.md, LICENSE, .gitignore, .gitattributes and .editorconfig
+It is recommended to execute the command after *npm init* in your project's root folder. It will then create a README.md, LICENSE, .gitignore, .gitattributes and .editorconfig.
 ```bash
 poketask init
 ```
@@ -21,7 +21,9 @@ author: Pablo Marmol
 license: mit
 gitignore workspace: node laravel
 ```
-It accepts multiple gitignore workspaces and license templates. It uses the github gitignore templates. You can see the list of gitignore templates [here](https://github.com/github/gitignore). And the list of license templates [here](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses).
+The project uses the github gitignore templates and also accepts multiple gitignore workspaces and license templates.
+
+The list of gitignore templates can be found [here](https://github.com/github/gitignore). And the list of license templates is [here](https://github.com/github/choosealicense.com/tree/gh-pages/_licenses).
 
 ## License
 Copyright &copy; 2018 Ricardo Huamani


### PR DESCRIPTION
- change multiple pronouns(it) to the referred subject/object to make the technical writing more clear and formal
- "one command line" -> "one-line command" (rearranged to put emphasis on the command)
- "Now" -> "Currently" (more formal)
- "It accepts multiple gitignore workspaces and license templates. It uses the github gitignore templates" -> "The project uses the github gitignore templates and also accepts multiple gitignore workspaces and license templates" (combined two sentences into one to add cohesion)

(This is from a CS student taking course Technical Writing. I hope this is not disturbing and thank you if the request is accepted. )